### PR TITLE
New sweep function and other updates

### DIFF
--- a/mops.toml
+++ b/mops.toml
@@ -1,0 +1,2 @@
+[toolchain]
+moc = "0.14.3"

--- a/src/main.mo
+++ b/src/main.mo
@@ -1,4 +1,5 @@
 import Cycles "mo:base/ExperimentalCycles";
+import Principal "mo:base/Principal";
 
 actor class (wallet : Text) {
   // See cycle wallet .did file:
@@ -6,24 +7,40 @@ actor class (wallet : Text) {
   type Wallet = actor {
     wallet_receive : () -> async ()
   };
+  
+  type IC = actor {
+    deposit_cycles : { canister_id : Principal } -> async ()
+  };
 
   public query func get() : async Nat {
     Cycles.balance();
   };
  
+  // When sweeping we have to hold some cycles back for response reservation
+  //   40B for processing 40B instructions
+  //   + 2B for 2 MB response size
+  //   + epsilon
+
+  // sweep through inter-canister wallet call
   public func sweep(keep : ?Nat) : async Nat {
     let amt : Nat = Cycles.balance() - (switch (keep) {
       case (?x) x * 1_000_000_000;
-      case _ 42_500_000_000;
-      // lowest tested value: 42_103_000_000
-      // it is for response reservation
-      // 40B for processing 40B instructions
-      // + 2B for 2 MB response size
+      case _ 42_200_000_000; // lowest tested value: 42_102_432_000
     });
-    Cycles.add<system>(amt);
     let dest : Wallet = actor (wallet);
-    await dest.wallet_receive();
+    await (with cycles = amt) dest.wallet_receive();
     amt
   };
- 
+
+  // sweep through management canister call
+  public func sweep2(keep : ?Nat) : async Nat {
+    let amt : Nat = Cycles.balance() - (switch (keep) {
+      case (?x) x * 1_000_000_000;
+      case _ 42_200_000_000; // lowest tested value: 42_102_453_000
+    });
+    let ic : IC = actor ("aaaaa-aa");
+    await (with cycles = amt) ic.deposit_cycles({ canister_id = Principal.fromText(wallet) });
+    amt
+  };
+
 };


### PR DESCRIPTION
* A second sweep function that uses deposit_cycles on mgmt canister
* Lower the default kept amount to 42.2 billion
* Use moc 0.14.2 syntax "with cycles"
* Add mops.toml file with toolchain

The new sweep function has no big advantage in general, but
* can sweep to any canister, not only to wallets
* might be faster if the sweep target is on another subnet (?)